### PR TITLE
Create SupabaseHttpHelper

### DIFF
--- a/backend/src/main/java/com/projectalpha/repository/address/impl/AddressRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/address/impl/AddressRepositoryImpl.java
@@ -1,63 +1,29 @@
 package com.projectalpha.repository.address.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.projectalpha.config.thirdparty.SupabaseConfig;
+import com.projectalpha.repository.util.SupabaseHttpHelper;
 import com.projectalpha.dto.business.address.AddressDTO;
 import com.projectalpha.repository.address.AddressRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class AddressRepositoryImpl implements AddressRepository {
 
-    private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
-    private final ObjectMapper objectMapper;
+    private final SupabaseHttpHelper httpHelper;
 
     @Autowired
-    public AddressRepositoryImpl(SupabaseConfig supabaseConfig) {
-        this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
-        this.objectMapper = new ObjectMapper();
+    public AddressRepositoryImpl(SupabaseHttpHelper httpHelper) {
+        this.httpHelper = httpHelper;
     }
 
     private List<AddressDTO> fetchList(String path) {
-        try {
-            String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
-
-            HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + resp.body());
-
-            JsonNode root = objectMapper.readTree(resp.body());
-            List<AddressDTO> list = new ArrayList<>();
-            for (JsonNode node : root) {
-                list.add(objectMapper.treeToValue(node, AddressDTO.class));
-            }
-            return list;
-
-        } catch (Exception e) {
-            throw new RuntimeException("Error fetching " + path, e);
-        }
+        return httpHelper.fetchList(path, AddressDTO.class);
     }
 
     private AddressDTO fetchSingle(String path) {
-        List<AddressDTO> list = fetchList(path);
-        return list.isEmpty() ? null : list.get(0);
+        return httpHelper.fetchSingle(path, AddressDTO.class);
     }
 
     @Override

--- a/backend/src/main/java/com/projectalpha/repository/businessTag/impl/BusinessTagRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/businessTag/impl/BusinessTagRepositoryImpl.java
@@ -1,59 +1,28 @@
 package com.projectalpha.repository.businessTag.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.projectalpha.config.thirdparty.SupabaseConfig;
+import com.projectalpha.repository.util.SupabaseHttpHelper;
 import com.projectalpha.dto.business.businessTag.BusinessTagDTO;
 import com.projectalpha.repository.businessTag.BusinessTagRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class BusinessTagRepositoryImpl implements BusinessTagRepository {
-    private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
-    private final ObjectMapper objectMapper;
+    private final SupabaseHttpHelper httpHelper;
 
     @Autowired
-    public BusinessTagRepositoryImpl(SupabaseConfig supabaseConfig) {
-        this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
-        this.objectMapper = new ObjectMapper();
+    public BusinessTagRepositoryImpl(SupabaseHttpHelper httpHelper) {
+        this.httpHelper = httpHelper;
     }
 
     private List<BusinessTagDTO> fetchList(String path) {
-        try {
-            String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
-
-            HttpResponse<String> r = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (r.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + r.body());
-
-            JsonNode root = objectMapper.readTree(r.body());
-            List<BusinessTagDTO> list = new ArrayList<>();
-            for (JsonNode n : root) list.add(objectMapper.treeToValue(n, BusinessTagDTO.class));
-            return list;
-        } catch (Exception e) {
-            throw new RuntimeException("Error fetching " + path, e);
-        }
+        return httpHelper.fetchList(path, BusinessTagDTO.class);
     }
 
     private BusinessTagDTO fetchSingle(String path) {
-        List<BusinessTagDTO> list = fetchList(path);
-        return list.isEmpty() ? null : list.get(0);
+        return httpHelper.fetchSingle(path, BusinessTagDTO.class);
     }
 
     @Override

--- a/backend/src/main/java/com/projectalpha/repository/photo/impl/PhotoRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/photo/impl/PhotoRepositoryImpl.java
@@ -1,59 +1,28 @@
 package com.projectalpha.repository.photo.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.projectalpha.config.thirdparty.SupabaseConfig;
+import com.projectalpha.repository.util.SupabaseHttpHelper;
 import com.projectalpha.dto.business.photo.PhotoDTO;
 import com.projectalpha.repository.photo.PhotoRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class PhotoRepositoryImpl implements PhotoRepository {
-    private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
-    private final ObjectMapper objectMapper;
+    private final SupabaseHttpHelper httpHelper;
 
     @Autowired
-    public PhotoRepositoryImpl(SupabaseConfig supabaseConfig) {
-        this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
-        this.objectMapper = new ObjectMapper();
+    public PhotoRepositoryImpl(SupabaseHttpHelper httpHelper) {
+        this.httpHelper = httpHelper;
     }
 
     private List<PhotoDTO> fetchList(String path) {
-        try {
-            String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
-
-            HttpResponse<String> r = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (r.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + r.body());
-
-            JsonNode root = objectMapper.readTree(r.body());
-            List<PhotoDTO> list = new ArrayList<>();
-            for (JsonNode n : root) list.add(objectMapper.treeToValue(n, PhotoDTO.class));
-            return list;
-        } catch (Exception e) {
-            throw new RuntimeException("Error fetching " + path, e);
-        }
+        return httpHelper.fetchList(path, PhotoDTO.class);
     }
 
     private PhotoDTO fetchSingle(String path) {
-        List<PhotoDTO> list = fetchList(path);
-        return list.isEmpty() ? null : list.get(0);
+        return httpHelper.fetchSingle(path, PhotoDTO.class);
     }
 
     @Override

--- a/backend/src/main/java/com/projectalpha/repository/restaurantSettings/impl/RestaurantSettingsRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/restaurantSettings/impl/RestaurantSettingsRepositoryImpl.java
@@ -1,63 +1,28 @@
 package com.projectalpha.repository.restaurantSettings.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.projectalpha.config.thirdparty.SupabaseConfig;
+import com.projectalpha.repository.util.SupabaseHttpHelper;
 import com.projectalpha.dto.business.restaurantsettings.RestaurantSettingsDTO;
 import com.projectalpha.repository.restaurantSettings.RestaurantSettingsRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class RestaurantSettingsRepositoryImpl implements RestaurantSettingsRepository {
-    private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
-    private final ObjectMapper objectMapper;
+    private final SupabaseHttpHelper httpHelper;
 
     @Autowired
-    public RestaurantSettingsRepositoryImpl(SupabaseConfig supabaseConfig) {
-        this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
-        this.objectMapper = new ObjectMapper();
+    public RestaurantSettingsRepositoryImpl(SupabaseHttpHelper httpHelper) {
+        this.httpHelper = httpHelper;
     }
 
     private List<RestaurantSettingsDTO> fetchList(String path) {
-        try {
-            String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
-
-            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() >= 400) {
-                throw new RuntimeException("Request failed [" + path + "]: " + resp.body());
-            }
-
-            JsonNode root = objectMapper.readTree(resp.body());
-            List<RestaurantSettingsDTO> list = new ArrayList<>();
-            for (JsonNode node : root) {
-                list.add(objectMapper.treeToValue(node, RestaurantSettingsDTO.class));
-            }
-            return list;
-        } catch (Exception e) {
-            throw new RuntimeException("Error fetching " + path, e);
-        }
+        return httpHelper.fetchList(path, RestaurantSettingsDTO.class);
     }
 
     private RestaurantSettingsDTO fetchSingle(String path) {
-        List<RestaurantSettingsDTO> list = fetchList(path);
-        return list.isEmpty() ? null : list.get(0);
+        return httpHelper.fetchSingle(path, RestaurantSettingsDTO.class);
     }
 
     @Override

--- a/backend/src/main/java/com/projectalpha/repository/tag/impl/TagRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/tag/impl/TagRepositoryImpl.java
@@ -1,59 +1,28 @@
 package com.projectalpha.repository.tag.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.projectalpha.config.thirdparty.SupabaseConfig;
+import com.projectalpha.repository.util.SupabaseHttpHelper;
 import com.projectalpha.dto.business.tag.TagDTO;
 import com.projectalpha.repository.tag.TagRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class TagRepositoryImpl implements TagRepository {
-    private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
-    private final ObjectMapper objectMapper;
+    private final SupabaseHttpHelper httpHelper;
 
     @Autowired
-    public TagRepositoryImpl(SupabaseConfig supabaseConfig) {
-        this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
-        this.objectMapper = new ObjectMapper();
+    public TagRepositoryImpl(SupabaseHttpHelper httpHelper) {
+        this.httpHelper = httpHelper;
     }
 
     private List<TagDTO> fetchList(String path) {
-        try {
-            String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
-
-            HttpResponse<String> r = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (r.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + r.body());
-
-            JsonNode root = objectMapper.readTree(r.body());
-            List<TagDTO> list = new ArrayList<>();
-            for (JsonNode n : root) list.add(objectMapper.treeToValue(n, TagDTO.class));
-            return list;
-        } catch (Exception e) {
-            throw new RuntimeException("Error fetching " + path, e);
-        }
+        return httpHelper.fetchList(path, TagDTO.class);
     }
 
     private TagDTO fetchSingle(String path) {
-        List<TagDTO> list = fetchList(path);
-        return list.isEmpty() ? null : list.get(0);
+        return httpHelper.fetchSingle(path, TagDTO.class);
     }
 
     @Override

--- a/backend/src/main/java/com/projectalpha/repository/util/SupabaseHttpHelper.java
+++ b/backend/src/main/java/com/projectalpha/repository/util/SupabaseHttpHelper.java
@@ -1,0 +1,70 @@
+package com.projectalpha.repository.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.projectalpha.config.thirdparty.SupabaseConfig;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility component for making HTTP requests to Supabase and mapping the
+ * JSON response to DTO classes.
+ */
+@Component
+public class SupabaseHttpHelper {
+    private final SupabaseConfig supabaseConfig;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SupabaseHttpHelper(SupabaseConfig supabaseConfig) {
+        this.supabaseConfig = supabaseConfig;
+    }
+
+    /**
+     * Fetches a list of DTOs from the given path under the Supabase REST API.
+     *
+     * @param path  the path relative to <code>/rest/v1/</code>
+     * @param clazz the DTO class
+     * @return a list of mapped DTO objects
+     */
+    public <T> List<T> fetchList(String path, Class<T> clazz) {
+        try {
+            String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("apikey", supabaseConfig.getSupabaseApiKey())
+                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
+                    .header("Content-Type", "application/json")
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                throw new RuntimeException("Request failed [" + path + "]: " + response.body());
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            List<T> result = new ArrayList<>();
+            for (JsonNode node : root) {
+                result.add(objectMapper.treeToValue(node, clazz));
+            }
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Error fetching " + path, e);
+        }
+    }
+
+    /**
+     * Fetches a single DTO from the given path under the Supabase REST API.
+     */
+    public <T> T fetchSingle(String path, Class<T> clazz) {
+        List<T> list = fetchList(path, clazz);
+        return list.isEmpty() ? null : list.get(0);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SupabaseHttpHelper` to centralize HTTP calls to Supabase
- refactor address, business, businessTag, photo, restaurant settings and tag repositories to use the helper

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6847369a134c832ca64ecf05d92b00ac