### PR TITLE
Use env for API base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Project Alpha
+
+## Environment Variables
+
+The frontend uses the `VITE_API_BASE_URL` variable to configure the base URL for API requests. Create a `.env` file inside the `frontend` directory and set:
+
+```
+VITE_API_BASE_URL=http://localhost:8080/api
+```
+
+Adjust the value as needed for your environment.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -3,8 +3,9 @@
  * Handles all API calls related to auth
  */
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 
-const API_URL = 'http://localhost:8080/api/auth';
+const API_URL = `${API_BASE_URL}/auth`;
 
 /**
  * Send verification code to email for registration
@@ -68,7 +69,7 @@ export const updateUser = async (email, password, role = 'user') => {
 export const login = async (email, password, role) => {
   try {
     const response = await axios.post(
-        "http://localhost:8080/api/auth/login",
+        `${API_URL}/login`,
         {
           email: email.trim(),
           password: password.trim(),
@@ -83,7 +84,7 @@ export const login = async (email, password, role) => {
 export const checkPassword = async (email, password, role) => {
   try {
     const response = await axios.post(
-        "http://localhost:8080/api/auth/login",
+        `${API_URL}/login`,
         {
           email: email.trim(),
           password: password.trim(),

--- a/frontend/src/services/businessService.js
+++ b/frontend/src/services/businessService.js
@@ -1,7 +1,8 @@
 
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 
-const API_BASE = 'http://localhost:8080/api/business';
+const API_BASE = `${API_BASE_URL}/business`;
 
 /**
  * Fetches all businesses.
@@ -76,3 +77,4 @@ export const getBusinessReviews = async (businessId) => {
     console.log(res.data.data);
     return res.data.data;
 }
+

--- a/frontend/src/services/listService.js
+++ b/frontend/src/services/listService.js
@@ -1,9 +1,10 @@
 // src/services/listService.js
 
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 import {getUserFavoritesIdFromStorage, getUserIdFromStorage} from "./userService.js";
 
-const API_URL = 'http://localhost:8080/api/users';
+const API_URL = `${API_BASE_URL}/users`;
 
 export const addToList = async (userId, listId, itemId) => {
     const response = await axios.post(`${API_URL}/diner_user/${userId}/lists/${listId}/items/${itemId}`, {});
@@ -88,3 +89,4 @@ export const toggleFavorite = async (id) => {
         return await getUserListItems(getUserIdFromStorage(), getUserFavoritesIdFromStorage());
     }
 }
+

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 
-const API_URL = 'http://localhost:8080/api/users';
+const API_URL = `${API_BASE_URL}/users`;
 
 /**
  * save user data to local storage


### PR DESCRIPTION
## Summary
- create `api.js` to centralize API base configuration
- update services to use `API_BASE_URL`
- document `VITE_API_BASE_URL` in root README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473be45800832cadc73f063da64beb