### PR TITLE
Replace credentials with env placeholders

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,13 +1,13 @@
 spring.application.name=projectalpha
 spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-spring.security.user.name=admin
-spring.security.user.password=1234
-spring.datasource.password = eRnhwuEDKKF8FHvX
-spring.datasource.username = postgres.jfqmvaeeelneeawbvkga
+spring.security.user.name=${ADMIN_USERNAME}
+spring.security.user.password=${ADMIN_PASSWORD}
+spring.datasource.password=${DB_PASSWORD}
+spring.datasource.username=${DB_USERNAME}
 
-supabase.url=https://jfqmvaeeelneeawbvkga.supabase.co
-supabase.apiKey=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpmcW12YWVlZWxuZWVhd2J2a2dhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU3MDAwNzgsImV4cCI6MjA2MTI3NjA3OH0.B9R9mUucwZCYXSuZPD3PKGcNUfR58Zb4Efb0kyUe2RM
-supabase.secretKey=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpmcW12YWVlZWxuZWVhd2J2a2dhIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0NTcwMDA3OCwiZXhwIjoyMDYxMjc2MDc4fQ.WG-0ef4z9yf84U5XfQR6_iMaObMMWZwVjga6u5fNu2w
+supabase.url=${SUPABASE_URL}
+supabase.apiKey=${SUPABASE_API_KEY}
+supabase.secretKey=${SUPABASE_SECRET_KEY}
 logging.level.org.springframework.web.client.RestTemplate=DEBUG
 logging.level.org.apache.http=DEBUG
 


### PR DESCRIPTION
## Summary
- switch hard-coded credentials in `application.properties` to use environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `bash backend/mvnw -f backend/pom.xml -q test` *(fails: could not resolve dependencies due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_68473fa26874832c829e3752fe7fb73d