### PR TITLE
Centralize frontend API base URL

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -3,8 +3,9 @@
  * Handles all API calls related to auth
  */
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 
-const API_URL = 'http://localhost:8080/api/auth';
+const API_URL = `${API_BASE_URL}/api/auth`;
 
 /**
  * Send verification code to email for registration
@@ -68,7 +69,7 @@ export const updateUser = async (email, password, role = 'user') => {
 export const login = async (email, password, role) => {
   try {
     const response = await axios.post(
-        "http://localhost:8080/api/auth/login",
+        `${API_URL}/login`,
         {
           email: email.trim(),
           password: password.trim(),
@@ -83,7 +84,7 @@ export const login = async (email, password, role) => {
 export const checkPassword = async (email, password, role) => {
   try {
     const response = await axios.post(
-        "http://localhost:8080/api/auth/login",
+        `${API_URL}/login`,
         {
           email: email.trim(),
           password: password.trim(),

--- a/frontend/src/services/businessService.js
+++ b/frontend/src/services/businessService.js
@@ -1,7 +1,8 @@
 
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 
-const API_BASE = 'http://localhost:8080/api/business';
+const API_BASE = `${API_BASE_URL}/api/business`;
 
 /**
  * Fetches all businesses.

--- a/frontend/src/services/listService.js
+++ b/frontend/src/services/listService.js
@@ -1,9 +1,10 @@
 // src/services/listService.js
 
 import axios from 'axios';
-import {getUserFavoritesIdFromStorage, getUserIdFromStorage} from "./userService.js";
+import { getUserFavoritesIdFromStorage, getUserIdFromStorage } from './userService.js';
+import { API_BASE_URL } from './api';
 
-const API_URL = 'http://localhost:8080/api/users';
+const API_URL = `${API_BASE_URL}/api/users`;
 
 export const addToList = async (userId, listId, itemId) => {
     const response = await axios.post(`${API_URL}/diner_user/${userId}/lists/${listId}/items/${itemId}`, {});

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { API_BASE_URL } from './api';
 
-const API_URL = 'http://localhost:8080/api/users';
+const API_URL = `${API_BASE_URL}/api/users`;
 
 /**
  * save user data to local storage


### PR DESCRIPTION
## Summary
- add a helper exporting `API_BASE_URL`
- build API URLs from this variable in service files

## Testing
- `npm install` *(in frontend)*
- `npm run lint` *(fails: no-unused-vars etc.)*
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68473fb47500832ca7f8d930736f7c68