### PR TITLE
Use SupabaseHttpHelper in repositories

### DIFF
--- a/backend/src/main/java/com/projectalpha/repository/address/impl/AddressRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/address/impl/AddressRepositoryImpl.java
@@ -9,9 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import com.projectalpha.util.SupabaseHttpHelper;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,31 +17,22 @@ import java.util.List;
 public class AddressRepositoryImpl implements AddressRepository {
 
     private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
+    private final SupabaseHttpHelper httpHelper;
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public AddressRepositoryImpl(SupabaseConfig supabaseConfig) {
+    public AddressRepositoryImpl(SupabaseConfig supabaseConfig, SupabaseHttpHelper httpHelper) {
         this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpHelper = httpHelper;
         this.objectMapper = new ObjectMapper();
     }
 
     private List<AddressDTO> fetchList(String path) {
         try {
             String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
+            String body = httpHelper.get(url);
 
-            HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + resp.body());
-
-            JsonNode root = objectMapper.readTree(resp.body());
+            JsonNode root = objectMapper.readTree(body);
             List<AddressDTO> list = new ArrayList<>();
             for (JsonNode node : root) {
                 list.add(objectMapper.treeToValue(node, AddressDTO.class));

--- a/backend/src/main/java/com/projectalpha/repository/businessTag/impl/BusinessTagRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/businessTag/impl/BusinessTagRepositoryImpl.java
@@ -9,40 +9,29 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import com.projectalpha.util.SupabaseHttpHelper;
 import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class BusinessTagRepositoryImpl implements BusinessTagRepository {
     private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
+    private final SupabaseHttpHelper httpHelper;
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public BusinessTagRepositoryImpl(SupabaseConfig supabaseConfig) {
+    public BusinessTagRepositoryImpl(SupabaseConfig supabaseConfig, SupabaseHttpHelper httpHelper) {
         this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpHelper = httpHelper;
         this.objectMapper = new ObjectMapper();
     }
 
     private List<BusinessTagDTO> fetchList(String path) {
         try {
             String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
+            String body = httpHelper.get(url);
 
-            HttpResponse<String> r = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (r.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + r.body());
-
-            JsonNode root = objectMapper.readTree(r.body());
+            JsonNode root = objectMapper.readTree(body);
             List<BusinessTagDTO> list = new ArrayList<>();
             for (JsonNode n : root) list.add(objectMapper.treeToValue(n, BusinessTagDTO.class));
             return list;

--- a/backend/src/main/java/com/projectalpha/repository/photo/impl/PhotoRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/photo/impl/PhotoRepositoryImpl.java
@@ -9,40 +9,29 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import com.projectalpha.util.SupabaseHttpHelper;
 import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class PhotoRepositoryImpl implements PhotoRepository {
     private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
+    private final SupabaseHttpHelper httpHelper;
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public PhotoRepositoryImpl(SupabaseConfig supabaseConfig) {
+    public PhotoRepositoryImpl(SupabaseConfig supabaseConfig, SupabaseHttpHelper httpHelper) {
         this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpHelper = httpHelper;
         this.objectMapper = new ObjectMapper();
     }
 
     private List<PhotoDTO> fetchList(String path) {
         try {
             String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
+            String body = httpHelper.get(url);
 
-            HttpResponse<String> r = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (r.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + r.body());
-
-            JsonNode root = objectMapper.readTree(r.body());
+            JsonNode root = objectMapper.readTree(body);
             List<PhotoDTO> list = new ArrayList<>();
             for (JsonNode n : root) list.add(objectMapper.treeToValue(n, PhotoDTO.class));
             return list;

--- a/backend/src/main/java/com/projectalpha/repository/tag/impl/TagRepositoryImpl.java
+++ b/backend/src/main/java/com/projectalpha/repository/tag/impl/TagRepositoryImpl.java
@@ -9,40 +9,29 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
+import com.projectalpha.util.SupabaseHttpHelper;
 import java.util.ArrayList;
 import java.util.List;
 
 @Repository
 public class TagRepositoryImpl implements TagRepository {
     private final SupabaseConfig supabaseConfig;
-    private final HttpClient httpClient;
+    private final SupabaseHttpHelper httpHelper;
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public TagRepositoryImpl(SupabaseConfig supabaseConfig) {
+    public TagRepositoryImpl(SupabaseConfig supabaseConfig, SupabaseHttpHelper httpHelper) {
         this.supabaseConfig = supabaseConfig;
-        this.httpClient = HttpClient.newHttpClient();
+        this.httpHelper = httpHelper;
         this.objectMapper = new ObjectMapper();
     }
 
     private List<TagDTO> fetchList(String path) {
         try {
             String url = supabaseConfig.getSupabaseUrl() + "/rest/v1/" + path;
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(url))
-                    .header("apikey", supabaseConfig.getSupabaseApiKey())
-                    .header("Authorization", "Bearer " + supabaseConfig.getSupabaseSecretKey())
-                    .header("Content-Type", "application/json")
-                    .GET()
-                    .build();
+            String body = httpHelper.get(url);
 
-            HttpResponse<String> r = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
-            if (r.statusCode() >= 400) throw new RuntimeException("Request failed [" + path + "]: " + r.body());
-
-            JsonNode root = objectMapper.readTree(r.body());
+            JsonNode root = objectMapper.readTree(body);
             List<TagDTO> list = new ArrayList<>();
             for (JsonNode n : root) list.add(objectMapper.treeToValue(n, TagDTO.class));
             return list;

--- a/backend/src/main/java/com/projectalpha/util/SupabaseHttpHelper.java
+++ b/backend/src/main/java/com/projectalpha/util/SupabaseHttpHelper.java
@@ -1,0 +1,78 @@
+package com.projectalpha.util;
+
+import com.projectalpha.config.thirdparty.SupabaseConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+@Component
+public class SupabaseHttpHelper {
+    private final SupabaseConfig config;
+    private final HttpClient httpClient;
+
+    @Autowired
+    public SupabaseHttpHelper(SupabaseConfig config) {
+        this.config = config;
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    private HttpRequest.Builder baseBuilder(String url) {
+        return HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("apikey", config.getSupabaseApiKey())
+                .header("Authorization", "Bearer " + config.getSupabaseSecretKey())
+                .header("Content-Type", "application/json");
+    }
+
+    public String get(String url) throws Exception {
+        HttpRequest request = baseBuilder(url).GET().build();
+        HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 400) {
+            throw new RuntimeException("Request failed: " + resp.body());
+        }
+        return resp.body();
+    }
+
+    public String post(String url, String body, String prefer) throws Exception {
+        HttpRequest.Builder builder = baseBuilder(url)
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (prefer != null) {
+            builder.header("Prefer", prefer);
+        }
+        HttpResponse<String> resp = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 400 && resp.statusCode() != 201) {
+            throw new RuntimeException("Request failed: " + resp.body());
+        }
+        return resp.body();
+    }
+
+    public String patch(String url, String body, String prefer) throws Exception {
+        HttpRequest.Builder builder = baseBuilder(url)
+                .method("PATCH", HttpRequest.BodyPublishers.ofString(body));
+        if (prefer != null) {
+            builder.header("Prefer", prefer);
+        }
+        HttpResponse<String> resp = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 400 && resp.statusCode() != 201) {
+            throw new RuntimeException("Request failed: " + resp.body());
+        }
+        return resp.body();
+    }
+
+    public String delete(String url, String prefer) throws Exception {
+        HttpRequest.Builder builder = baseBuilder(url).DELETE();
+        if (prefer != null) {
+            builder.header("Prefer", prefer);
+        }
+        HttpResponse<String> resp = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() >= 400 && resp.statusCode() != 204) {
+            throw new RuntimeException("Request failed: " + resp.body());
+        }
+        return resp.body();
+    }
+}


### PR DESCRIPTION
## Summary
- add `SupabaseHttpHelper` utility
- refactor repository implementations to use the helper instead of manual `HttpClient` setup

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68473fb9b514832c8d53cb7845b99392