### PR TITLE
Add dotenv config loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ build/
 
 ### Node Modules ###
 node_modules/
+
+# Ignore environment files
+backend/.env
+frontend/.env
+*.env

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Set the following variables so the backend can connect to Supabase and the datab
 - `DB_USERNAME` – Database username.
 - `DB_PASSWORD` – Database password.
 
-The Spring Boot application reads these values from the environment. You can export them in your shell before running the application, or place them in a `.env` file and use a tool such as [`dotenv`](https://github.com/cdimascio/dotenv-java) or your IDE to load them.
+The Spring Boot application reads these values from the environment. A `.env` file placed in the `backend/` directory will be loaded automatically at startup thanks to the included [`dotenv-java`](https://github.com/cdimascio/dotenv-java) library. You can also export the variables in your shell if you prefer.
 
 ## Frontend environment variables
 The Vite frontend expects the following variables (all must start with the `VITE_` prefix):
@@ -25,8 +25,9 @@ The Vite frontend expects the following variables (all must start with the `VITE
 Create a `frontend/.env` file or export the variables in your shell so that Vite can load them when you run `npm run dev` or build the project.
 
 ## Example `.env` files
+The repository contains `.env.example` files in both the `backend/` and `frontend/` directories. Copy them to `.env` and fill in your own values:
 ```bash
-# backend/.env or system environment
+# backend/.env
 SUPABASE_URL=https://<your-supabase-url>
 SUPABASE_API_KEY=...
 SUPABASE_SECRET_KEY=...
@@ -43,4 +44,4 @@ VITE_SUPABASE_ANON_KEY=...
 VITE_API_BASE_URL=http://localhost:8080
 ```
 
-After setting the variables, start the backend and frontend normally. The applications will read the configuration from the environment.
+After setting the variables, start the backend and frontend normally. The backend will automatically load values from `backend/.env` at startup so you don't need to export them manually.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+# Backend environment configuration
+SUPABASE_URL=https://<your-supabase-url>
+SUPABASE_API_KEY=<your-supabase-api-key>
+SUPABASE_SECRET_KEY=<your-supabase-service-key>
+ADMIN_USERNAME=<admin-user>
+ADMIN_PASSWORD=<admin-password>
+DB_USERNAME=<db-user>
+DB_PASSWORD=<db-pass>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -91,10 +91,15 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-thymeleaf</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>io.github.cdimascio</groupId>
+                        <artifactId>dotenv-java</artifactId>
+                        <version>3.0.0</version>
+                </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>

--- a/backend/src/main/java/com/projectalpha/ProjectAlphaApplication.java
+++ b/backend/src/main/java/com/projectalpha/ProjectAlphaApplication.java
@@ -7,11 +7,17 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
+import io.github.cdimascio.dotenv.Dotenv;
 
 @SpringBootApplication
 @EnableScheduling
 public class ProjectAlphaApplication {
     public static void main(String[] args) {
+        Dotenv dotenv = Dotenv.configure()
+                .ignoreIfMissing()
+                .load();
+        dotenv.entries().forEach(entry -> System.setProperty(entry.getKey(), entry.getValue()));
+
         SpringApplication.run(ProjectAlphaApplication.class, args);
     }
     @Bean

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# Frontend environment configuration
+VITE_SUPABASE_URL=https://<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+VITE_API_BASE_URL=http://localhost:8080


### PR DESCRIPTION
## Summary
- ignore `.env` files in git
- load backend environment variables via `dotenv-java`
- document automatic `.env` loading
- add example env files for frontend and backend

## Testing
- `./mvnw -q test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684747cd4e3c832c8c1fc063760d4b73